### PR TITLE
Fix form validation bug

### DIFF
--- a/js/objetos.js
+++ b/js/objetos.js
@@ -152,14 +152,14 @@ class Datos {
     }
 
     #setearErrores(){
-        if (convertirEnInt(this.#entrada.value) < 450) {
+        if (this.#entrada.value !== "" && convertirEnInt(this.#entrada.value) < 450) {
             let errorEntrada = document.getElementById(`errorEntrada${this.#dia}`);
             let error = document.createElement("p");
             error.className = "my-1";
             error.innerText = " * La entrada debe ser a partir de las 07:30";
             errorEntrada.appendChild(error);
         }
-        if (convertirEnInt(this.#salida.value) < 930) {
+        if (this.#salida.value !== "" && convertirEnInt(this.#salida.value) < 930) {
             let errorSalida = document.getElementById(`errorSalida${this.#dia}`);
             let error2 = document.createElement("p");
             error2.className = "my-1";
@@ -287,7 +287,7 @@ class Total {
     #devolerDiferenciaTotal(l, ma, mi, j, v) {
         let aux = 0;
         if (l.getEntrada().value != "" && l.getSalida().value != "") {
-            aux += convertirEnInt(l.getSalida().value) - (convertirEnInt(l.getEntrada().value)+450);;
+            aux += convertirEnInt(l.getSalida().value) - (convertirEnInt(l.getEntrada().value)+450);
         }
 
         if (ma.getEntrada().value != "" && ma.getSalida().value != "") {


### PR DESCRIPTION
## Summary
- avoid showing validation errors when entry/exit fields are empty
- remove stray semicolon in totals logic

## Testing
- `node --check js/objetos.js`
- `node --check js/funciones.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_b_6840b631ddb0832696e4721e8af39750