### PR TITLE
Add Jest tests and docs

### DIFF
--- a/js/funciones.js
+++ b/js/funciones.js
@@ -154,3 +154,8 @@ function eventosDia (obj, total) {
         total.guardar();
     });
 }
+
+// Export functions for testing in Node environments
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { convertirEnHora, convertirEnInt };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "horario-trabajo",
+  "version": "1.0.0",
+  "description": "La página fue pensada para empleados de una Empresa con el motivo de poder llevar un control sobre su jornada de trabajo y el uso de la jornada flexible.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -7,3 +7,21 @@ La página fue pensada para empleados de una Empresa con el motivo de poder llev
 Soy Nicolás Temprano de la ciudad de La Plata y estoy estudiando la carrera de Licenciatura en Sistemas en la Facultad de Informática (UNLP).
 
 Actualmente, estoy capacitandome para poder desempeñarme en un futuro como desarrollador Fullstack.
+
+## Tests
+
+Este proyecto incluye una pequeña suite de pruebas con **Jest** ubicada en el directorio `tests/`.
+
+### Ejecutar las pruebas
+
+1. Instalar las dependencias (requiere acceso a internet):
+   ```bash
+   npm install
+   ```
+
+2. Ejecutar Jest:
+   ```bash
+   npm test
+   ```
+
+Las pruebas verifican el correcto funcionamiento de `convertirEnHora` y `convertirEnInt`.

--- a/tests/funciones.test.js
+++ b/tests/funciones.test.js
@@ -1,0 +1,17 @@
+const { convertirEnHora, convertirEnInt } = require('../js/funciones');
+
+test('convertirEnHora convierte 450 en "07:30"', () => {
+    expect(convertirEnHora(450)).toBe('07:30');
+});
+
+test('convertirEnHora convierte 930 en "15:30"', () => {
+    expect(convertirEnHora(930)).toBe('15:30');
+});
+
+test('convertirEnInt convierte "07:30" en 450', () => {
+    expect(convertirEnInt('07:30')).toBe(450);
+});
+
+test('convertirEnInt convierte "15:30" en 930', () => {
+    expect(convertirEnInt('15:30')).toBe(930);
+});


### PR DESCRIPTION
## Summary
- add `jest` setup in `package.json`
- add export helpers in `funciones.js`
- create `tests/funciones.test.js`
- document running the new Jest suite

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840b7dcdf248326ae182116c0be59ba