### PR TITLE
Fix duplicate error IDs for each weekday

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@
                 </div>
                 <!-- LUNES -->
                 <div class="d-flex flex-column d-lg-none border-top">
-                    <div class="text-danger py-auto mx-5 fst-italic" style="font-size: 12px" id="errorEntradaLunes"></div>
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaLunes"></div>
+                    <div class="text-danger py-auto mx-5 fst-italic" style="font-size: 12px" id="errorEntradaLunesMobile"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaLunesMobile"></div>
                 </div>
                 <div class="d-flex d-lg-block">
                     <div class="d-none d-lg-flex flex-row border-top">
-                        <div class="text-danger py-auto mx-5 fst-italic" style="font-size: 12px" id="errorEntradaLunes"></div>
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaLunes"></div>
+                        <div class="text-danger py-auto mx-5 fst-italic" style="font-size: 12px" id="errorEntradaLunesDesktop"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaLunesDesktop"></div>
                     </div>
                     <!-- Encabezado. Se ve solo en dispositivos de resolución menor a 992px -->
                     <div class="d-flex flex-column w-100 pt-2 pb-0 mx-0 d-lg-none">
@@ -103,13 +103,13 @@
                 </div>
                 <!-- MARTES -->
                 <div class="d-flex flex-column d-lg-none border-top bg-secondary bg-opacity-10">
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMartes"></div>
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMartes"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMartesMobile"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMartesMobile"></div>
                 </div>
                 <div class="d-flex d-lg-block bg-secondary bg-opacity-10">
                     <div class="d-none d-lg-flex border-top flex-row">
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMartes"></div>
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMartes"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMartesDesktop"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMartesDesktop"></div>
                     </div>
                     <!-- Encabezado. Se ve solo en dispositivos de resolución menor a 992px -->
                     <div class="d-flex flex-column w-100 pt-2 pb-0 mx-0 d-lg-none">
@@ -168,13 +168,13 @@
                 </div>
                 <!-- MIERCOLES -->
                 <div class="d-flex flex-column d-lg-none border-top">
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMiercoles"></div>
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMiercoles"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMiercolesMobile"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMiercolesMobile"></div>
                 </div>
                 <div class="d-flex d-lg-block">
                     <div class="d-none d-lg-flex flex-row border-top">
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMiercoles"></div>
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMiercoles"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaMiercolesDesktop"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaMiercolesDesktop"></div>
                     </div>
                     <!-- Encabezado. Se ve solo en dispositivos de resolución menor a 992px -->
                     <div class="d-flex flex-column w-100 pt-2 pb-0 mx-0 d-lg-none">
@@ -233,13 +233,13 @@
                 </div>
                 <!-- JUEVES -->
                 <div class="d-flex flex-column d-lg-none border-top bg-secondary bg-opacity-10">
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaJueves"></div>
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaJueves"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaJuevesMobile"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaJuevesMobile"></div>
                 </div>
                 <div class="d-flex d-lg-block bg-secondary bg-opacity-10">
                     <div class="d-none d-lg-flex flex-row border-top">
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaJueves"></div>
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaJueves"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaJuevesDesktop"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaJuevesDesktop"></div>
                     </div>
                     <!-- Encabezado. Se ve solo en dispositivos de resolución menor a 992px -->
                     <div class="d-flex flex-column w-100 pt-2 pb-0 mx-0 d-lg-none">
@@ -298,13 +298,13 @@
                 </div>
                 <!-- VIERNES -->
                 <div class="d-flex flex-column d-lg-none border-top">
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaViernes"></div>
-                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaViernes"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaViernesMobile"></div>
+                    <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaViernesMobile"></div>
                 </div>
                 <div class="d-flex d-lg-block border-bottom">
                     <div class="d-none d-lg-flex flex-row flex-row border-top">
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaViernes"></div>
-                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaViernes"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorEntradaViernesDesktop"></div>
+                        <div class="text-danger mx-5 fst-italic" style="font-size: 12px" id="errorSalidaViernesDesktop"></div>
                     </div>
                     <!-- Encabezado. Se ve solo en dispositivos de resolución menor a 992px -->
                     <div class="d-flex flex-column w-100 pt-2 pb-0 mx-0 d-lg-none">

--- a/js/funciones.js
+++ b/js/funciones.js
@@ -86,21 +86,25 @@ function eventosDia (obj, total) {
 
     // Mira si hay cambios en el horario de entrada
     obj.getEntrada().addEventListener("change", () => {
-        // Traigo el div que contiene el mensaje de error
-        let divError = document.getElementById(`errorEntrada${obj.getDia()}`);
+        // Traigo los contenedores que muestran el mensaje de error
+        let divErrores = document.querySelectorAll(
+            `#errorEntrada${obj.getDia()}Mobile, #errorEntrada${obj.getDia()}Desktop`
+        );
         // Si hay un cambio no sé si va a haber error con el nuevo cambio
-        // Por lo tanto borro el contenido
-        divError.innerHTML = "";
+        // Por lo tanto borro el contenido de ambos contenedores
+        divErrores.forEach(div => div.innerHTML = "");
         // Me fijo si hay error (puse que entré antes de las 7:30)
         if (convertirEnInt(obj.getEntrada().value) < 450) {
             // Creo un elemento <p></p> que va a contener el error
-            let error = document.createElement("p");
-            // Le agrego la clase
-            error.className = "my-1";
-            // Defino el mensaje de error
-            error.innerText = " * La entrada debe ser a partir de las 07:30";
-            // Lo agrego al div
-            divError.appendChild(error);
+            divErrores.forEach(div => {
+                let error = document.createElement("p");
+                // Le agrego la clase
+                error.className = "my-1";
+                // Defino el mensaje de error
+                error.innerText = " * La entrada debe ser a partir de las 07:30";
+                // Lo agrego al div correspondiente
+                div.appendChild(error);
+            });
         }
         obj.setearDeberiaSalir();
         if (obj.getTenerEnCuenta().value == "true") {
@@ -136,13 +140,17 @@ function eventosDia (obj, total) {
 
     // Mira si hay cambios en el horario de salida
     obj.getSalida().addEventListener("change", () => {
-        let divError = document.getElementById(`errorSalida${obj.getDia()}`);
-        divError.innerHTML = "";
+        let divErrores = document.querySelectorAll(
+            `#errorSalida${obj.getDia()}Mobile, #errorSalida${obj.getDia()}Desktop`
+        );
+        divErrores.forEach(div => div.innerHTML = "");
         if (convertirEnInt(obj.getSalida().value) < 930) {
-            let error = document.createElement("p");
-            error.className = "my-1";
-            error.innerText = " * La salida debe ser a partir de las 15:30";
-            divError.appendChild(error);
+            divErrores.forEach(div => {
+                let error = document.createElement("p");
+                error.className = "my-1";
+                error.innerText = " * La salida debe ser a partir de las 15:30";
+                div.appendChild(error);
+            });
         }
         if (obj.getSalida().value == "") {
             obj.limpiar();

--- a/js/objetos.js
+++ b/js/objetos.js
@@ -153,18 +153,26 @@ class Datos {
 
     #setearErrores(){
         if (convertirEnInt(this.#entrada.value) < 450) {
-            let errorEntrada = document.getElementById(`errorEntrada${this.#dia}`);
-            let error = document.createElement("p");
-            error.className = "my-1";
-            error.innerText = " * La entrada debe ser a partir de las 07:30";
-            errorEntrada.appendChild(error);
+            let erroresEntrada = document.querySelectorAll(
+                `#errorEntrada${this.#dia}Mobile, #errorEntrada${this.#dia}Desktop`
+            );
+            erroresEntrada.forEach(div => {
+                let error = document.createElement("p");
+                error.className = "my-1";
+                error.innerText = " * La entrada debe ser a partir de las 07:30";
+                div.appendChild(error);
+            });
         }
         if (convertirEnInt(this.#salida.value) < 930) {
-            let errorSalida = document.getElementById(`errorSalida${this.#dia}`);
-            let error2 = document.createElement("p");
-            error2.className = "my-1";
-            error2.innerText = " * La salida debe ser a partir de las 15:30";
-            errorSalida.appendChild(error2);
+            let erroresSalida = document.querySelectorAll(
+                `#errorSalida${this.#dia}Mobile, #errorSalida${this.#dia}Desktop`
+            );
+            erroresSalida.forEach(div => {
+                let error2 = document.createElement("p");
+                error2.className = "my-1";
+                error2.innerText = " * La salida debe ser a partir de las 15:30";
+                div.appendChild(error2);
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- make every error container have a unique identifier
- update `eventosDia` logic to handle mobile and desktop error containers
- adjust `Datos` helper to show errors in both layouts

## Testing
- `node --check js/funciones.js`
- `node --check js/objetos.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_b_6840b7d8fdb88326817574e0dd4fe641